### PR TITLE
Fix demo2 cache problem

### DIFF
--- a/demo2-cache/service-worker.js
+++ b/demo2-cache/service-worker.js
@@ -30,8 +30,10 @@ self.addEventListener("activate", (event) => {
         caches.keys()
         .then((allCaches) => {
             allCaches.map((cacheName) => {
-                console.log("Delete cache. " + cacheName);
-                return caches.delete(cacheName);
+                if (cacheName !== 'demo') {
+                    console.log("Delete cache. " + cacheName);
+                    return caches.delete(cacheName);
+                }
             });
         })
     );


### PR DESCRIPTION
Right now at activate event, it will delete all the cache from this url.
We need to mark a whitelist of the caches we don't want to delete (which
in this case I just check if cacheName !== 'demo' then don't delete it).
